### PR TITLE
fix: improve color contrast for WCAG accessibility

### DIFF
--- a/src/components/ContactCta.astro
+++ b/src/components/ContactCta.astro
@@ -105,7 +105,7 @@ import { MessageCircle, Phone, ArrowRight } from "lucide-react";
                 </div>
 
                 <div class="mt-6 text-center">
-                    <p class="text-xs text-slate-400">
+                    <p class="text-xs text-slate-600">
                         Liever mailen? <a
                             href="mailto:info@vanderveen-elektro.nl"
                             class="text-primary font-medium hover:underline"

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -81,7 +81,7 @@ import heroImage from "../assets/images/electrician-working-electrical-box.webp"
                 <div class="flex flex-col sm:flex-row gap-4">
                     <a href="/offerte/" class="btn-primary">
                         Offerte Aanvragen
-                        <span class="ml-2 text-white/80 text-xs font-normal"
+                        <span class="ml-2 text-white text-xs font-normal"
                             >(Gratis)</span
                         >
                     </a>
@@ -124,7 +124,7 @@ import heroImage from "../assets/images/electrician-working-electrical-box.webp"
                                 <p class="text-sm font-bold text-white">
                                     Actief in Culemborg
                                 </p>
-                                <p class="text-xs text-white/70">
+                                <p class="text-xs text-white/90">
                                     Onze monteurs zijn nu in de buurt
                                 </p>
                             </div>

--- a/src/components/TrustRow.astro
+++ b/src/components/TrustRow.astro
@@ -16,7 +16,7 @@ import { ShieldCheck, Award, ThumbsUp, CheckCircle } from "lucide-react";
                 </div>
                 <div class="flex flex-col">
                     <span
-                        class="text-xs font-bold text-slate-400 uppercase tracking-wider"
+                        class="text-xs font-bold text-slate-600 uppercase tracking-wider"
                         >Certificering</span
                     >
                     <span class="text-sm font-bold text-primary font-heading"
@@ -34,7 +34,7 @@ import { ShieldCheck, Award, ThumbsUp, CheckCircle } from "lucide-react";
                 </div>
                 <div class="flex flex-col">
                     <span
-                        class="text-xs font-bold text-slate-400 uppercase tracking-wider"
+                        class="text-xs font-bold text-slate-600 uppercase tracking-wider"
                         >Erkend</span
                     >
                     <span class="text-sm font-bold text-primary font-heading"
@@ -52,7 +52,7 @@ import { ShieldCheck, Award, ThumbsUp, CheckCircle } from "lucide-react";
                 </div>
                 <div class="flex flex-col">
                     <span
-                        class="text-xs font-bold text-slate-400 uppercase tracking-wider"
+                        class="text-xs font-bold text-slate-600 uppercase tracking-wider"
                         >Veiligheid</span
                     >
                     <span class="text-sm font-bold text-primary font-heading"
@@ -70,7 +70,7 @@ import { ShieldCheck, Award, ThumbsUp, CheckCircle } from "lucide-react";
                 </div>
                 <div class="flex flex-col">
                     <span
-                        class="text-xs font-bold text-slate-400 uppercase tracking-wider"
+                        class="text-xs font-bold text-slate-600 uppercase tracking-wider"
                         >Garantie</span
                     >
                     <span class="text-sm font-bold text-primary font-heading"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -114,7 +114,7 @@ const {
             <slot />
         </main>
 
-        <footer class="bg-primary text-slate-300 py-12 mt-auto">
+        <footer class="bg-primary text-slate-200 py-12 mt-auto">
             <!-- Todo: Footer Component -->
             <div
                 class="container-custom grid grid-cols-1 md:grid-cols-4 gap-12"
@@ -241,11 +241,11 @@ const {
             </div>
 
             <div
-                class="container-custom mt-12 pt-8 border-t border-slate-800 text-xs text-slate-500 flex flex-col md:flex-row justify-between items-center"
+                class="container-custom mt-12 pt-8 border-t border-slate-700 text-xs text-slate-300 flex flex-col md:flex-row justify-between items-center"
             >
                 <p>
                     &copy; {new Date().getFullYear()} Van der Veen Elektrotechniek.
-                    Gemaakt door <a href="https://knapgemaakt.nl/website-laten-maken/" target="_blank" rel="noopener" class="text-slate-400 hover:text-white transition-colors">KNAP GEMAAKT.</a>
+                    Gemaakt door <a href="https://knapgemaakt.nl/website-laten-maken/" target="_blank" rel="noopener" class="text-slate-200 underline hover:text-white transition-colors">KNAP GEMAAKT.</a>
                 </p>
                 <p>KvK: 12345678 | BTW: NL123456789B01</p>
             </div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -38,7 +38,7 @@ import { Phone, Mail, MapPin, Clock, ArrowRight } from "lucide-react";
                             </div>
                             <div>
                                 <span
-                                    class="block text-sm font-bold text-slate-400 uppercase tracking-wider mb-1"
+                                    class="block text-sm font-bold text-slate-600 uppercase tracking-wider mb-1"
                                     >Voor Spoed & Afspraken</span
                                 >
                                 <a
@@ -60,7 +60,7 @@ import { Phone, Mail, MapPin, Clock, ArrowRight } from "lucide-react";
                             </div>
                             <div>
                                 <span
-                                    class="block text-sm font-bold text-slate-400 uppercase tracking-wider mb-1"
+                                    class="block text-sm font-bold text-slate-600 uppercase tracking-wider mb-1"
                                     >E-mail</span
                                 >
                                 <a
@@ -82,7 +82,7 @@ import { Phone, Mail, MapPin, Clock, ArrowRight } from "lucide-react";
                             </div>
                             <div>
                                 <span
-                                    class="block text-sm font-bold text-slate-400 uppercase tracking-wider mb-1"
+                                    class="block text-sm font-bold text-slate-600 uppercase tracking-wider mb-1"
                                     >Locatie</span
                                 >
                                 <p class="text-lg font-bold text-primary">

--- a/src/pages/projecten/groepenkast-lanxmeer.astro
+++ b/src/pages/projecten/groepenkast-lanxmeer.astro
@@ -174,7 +174,7 @@ import heroImage from "../../assets/images/worker-working-on-electrical-box.webp
                         <h3 class="font-bold text-lg mb-3">
                             Ook uw groepenkast vervangen?
                         </h3>
-                        <p class="text-white/80 text-sm mb-4">
+                        <p class="text-white/90 text-sm mb-4">
                             Wij adviseren u graag over de mogelijkheden voor uw
                             situatie.
                         </p>

--- a/src/pages/projecten/laadpaal-beusichem.astro
+++ b/src/pages/projecten/laadpaal-beusichem.astro
@@ -172,7 +172,7 @@ import heroImage from "../../assets/images/home-car-charger.webp";
                         <h3 class="font-bold text-lg mb-3">
                             Ook thuis laden?
                         </h3>
-                        <p class="text-white/80 text-sm mb-4">
+                        <p class="text-white/90 text-sm mb-4">
                             Wij adviseren u over de beste laadoplossing voor uw
                             situatie en auto.
                         </p>

--- a/src/pages/projecten/verlichting-centrum.astro
+++ b/src/pages/projecten/verlichting-centrum.astro
@@ -172,7 +172,7 @@ import heroImage from "../../assets/images/electrical-measurement-tools.webp";
                         <h3 class="font-bold text-lg mb-3">
                             Ook een lichtplan nodig?
                         </h3>
-                        <p class="text-white/80 text-sm mb-4">
+                        <p class="text-white/90 text-sm mb-4">
                             Wij denken graag mee over de perfecte verlichting
                             voor uw ruimte.
                         </p>

--- a/src/pages/projecten/zonnepanelen-tiel.astro
+++ b/src/pages/projecten/zonnepanelen-tiel.astro
@@ -171,7 +171,7 @@ import heroImage from "../../assets/images/electrician-installing-solar-panels.w
                         <h3 class="font-bold text-lg mb-3">
                             Zonnepanelen laten aansluiten?
                         </h3>
-                        <p class="text-white/80 text-sm mb-4">
+                        <p class="text-white/90 text-sm mb-4">
                             Wij verzorgen de veilige aansluiting van uw
                             omvormer conform alle normen.
                         </p>


### PR DESCRIPTION
## Summary
- Improve text contrast ratios to meet WCAG 2.1 AA guidelines
- Add underline to footer link for distinguishability without relying on color alone

## Changes
- `text-slate-400` → `text-slate-600` for light backgrounds (TrustRow labels, contact page)
- `text-white/80` → `text-white` on primary buttons
- `text-white/80` → `text-white/90` on dark backgrounds
- Footer text colors improved for better contrast
- Added underline to "KNAP GEMAAKT." link

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)