### PR TITLE
fix: improve WhatsApp button color contrast for WCAG accessibility (#6)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,7 +20,7 @@
   --color-text-muted: #64748b; /* Slate 500 */
 
   /* Brand Colors */
-  --color-whatsapp: #25D366;
+  --color-whatsapp: #1a7f37;
   --color-rating: #F59E0B; /* Amber 500 - Star ratings */
 
   /* Service Icon Colors - Consistent accent-based system */


### PR DESCRIPTION
## Summary
- Darkened WhatsApp button background color from `#25D366` to `#1a7f37`
- Achieves ~5.6:1 contrast ratio with white text (WCAG AA requires 4.5:1)
- Maintains recognizable WhatsApp green appearance

## Test plan
- [ ] Verify WhatsApp button is visually readable with white text
- [ ] Run Lighthouse accessibility audit — no contrast warnings on WhatsApp button
- [ ] Visual check that the button still looks like a WhatsApp CTA

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)