### PR TITLE
fix: Google Fonts MIME type error

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,12 @@ const {
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <meta name="generator" content={Astro.generator} />
+
+        <!-- Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400..700&family=Inter:wght@300..600&display=swap" rel="stylesheet" />
+
         <title>{title}</title>
     </head>
     <body class="bg-surface text-text antialiased flex flex-col min-h-screen">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;500;700&family=Inter:wght@300;400;500;600&display=swap');
 @import "tailwindcss";
 
 @theme {


### PR DESCRIPTION
## Summary

- Moved Google Fonts from CSS `@import` to HTML `<link>` tags
- Added preconnect hints for fonts.googleapis.com and fonts.gstatic.com
- Updated font URL to use variable weight ranges for cleaner syntax

Fixes the browser console error:
```
Refused to apply style from Google Fonts because its MIME type ('text/html') is not a supported stylesheet MIME type
```

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)