### PR TITLE
fix: prevent demo site from being indexed by search engines 🐛

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,7 @@ const {
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <meta name="generator" content={Astro.generator} />
+        <meta name="robots" content="noindex, nofollow" />
 
         <!-- Google Fonts -->
         <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -255,7 +256,7 @@ const {
             >
                 <p>
                     &copy; {new Date().getFullYear()} Van der Veen Elektrotechniek.
-                    Gemaakt door <a href="https://knapgemaakt.nl/website-laten-maken/" target="_blank" rel="noopener" class="text-slate-200 underline hover:text-white transition-colors">KNAP GEMAAKT.</a>
+                    Gemaakt door <a href="https://knapgemaakt.nl/website-laten-maken/" target="_blank" rel="noopener nofollow" class="text-slate-200 underline hover:text-white transition-colors">KNAP GEMAAKT.</a>
                 </p>
                 <p>KvK: 12345678 | BTW: NL123456789B01</p>
             </div>


### PR DESCRIPTION
## Summary
- Add `<meta name="robots" content="noindex, nofollow">` to the `<head>` in the base layout
- Add `nofollow` to the outbound knapgemaakt.nl link in the footer

`robots.txt` alone doesn't prevent indexing — Google can still index URLs discovered via external links. The `noindex` meta tag tells Google to drop pages from search results entirely.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)